### PR TITLE
allow `secret_key` query param to be sent through to API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+ ## Open Traffic ~ Tangram Demo
 
+To use against a live [OTv2 API](https://github.com/opentraffic/api), you will need to specify two query parameters:
 
- ## OpenTraffic ~ Tangram Demo
- 
+- `server` - hostname for the API
+- `secret_key` - to authenticate against the API
+
+For example: `http://opentraffic.io/tangram-viz-experiments/?server=host.opentraffic.io&secret=password`
+
  ### How does it work?
  
  The pipeline for this is:

--- a/index.html
+++ b/index.html
@@ -742,6 +742,9 @@
                 // Get the current boundaries of the displayed area on the map
                 var bbox = map.getBounds();
                 var url = 'https://'+query.server+'/query?';
+                if (query.secret_key) {
+                    url = url + 'secret_key=' + query.secret_key + '&';
+                }
 
                 //console.log( query )
 


### PR DESCRIPTION
related to https://github.com/opentraffic/api/commit/9b166e007a46633fac4199ae7bba647b6f3e1abe
related to https://github.com/mapzen/open-traffic/issues/42
